### PR TITLE
Removing running maven clean before exec

### DIFF
--- a/generator/project/core/README.adoc.ftl
+++ b/generator/project/core/README.adoc.ftl
@@ -33,7 +33,7 @@ To package your application:
 To run your application:
 <#if buildTool == "maven">
 ```
-./mvnw clean exec:java
+./mvnw exec:java
 ```
 </#if>
 <#if buildTool == 'gradle'>


### PR DESCRIPTION
Running clean before exec, is cleaning the target directory getting the following exception:

SEVERE: Failed in deploying verticle
java.lang.ClassNotFoundException: com.xala3pa.teashop.MainVerticle
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at io.vertx.core.impl.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:37)
	at io.vertx.core.impl.DeploymentManager.createVerticles(DeploymentManager.java:238)
	at io.vertx.core.impl.DeploymentManager.lambda$doDeployVerticle$2(DeploymentManager.java:211)
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79)
	at io.vertx.core.impl.DeploymentManager.doDeployVerticle(DeploymentManager.java:178)
	at io.vertx.core.impl.DeploymentManager.doDeployVerticle(DeploymentManager.java:151)
	at io.vertx.core.impl.DeploymentManager.deployVerticle(DeploymentManager.java:140)
	at io.vertx.core.impl.VertxImpl.deployVerticle(VertxImpl.java:677)
	at io.vertx.core.impl.launcher.commands.VertxIsolatedDeployer.deploy(VertxIsolatedDeployer.java:42)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.vertx.core.impl.launcher.commands.ClasspathHandler.deploy(ClasspathHandler.java:159)
	at io.vertx.core.impl.launcher.commands.RunCommand.deploy(RunCommand.java:403)
	at io.vertx.core.impl.launcher.commands.RunCommand.run(RunCommand.java:270)
	at io.vertx.core.impl.launcher.VertxCommandLauncher.execute(VertxCommandLauncher.java:226)
	at io.vertx.core.impl.launcher.VertxCommandLauncher.dispatch(VertxCommandLauncher.java:361)
	at io.vertx.core.impl.launcher.VertxCommandLauncher.dispatch(VertxCommandLauncher.java:324)
	at io.vertx.core.Launcher.main(Launcher.java:45)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:294)
	at java.base/java.lang.Thread.run(Thread.java:834)`
`